### PR TITLE
Add debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install: all
 clean:
 		# Nothing to do here
 test:
-	PERL5LIB=tlib/:lib/ prove -Itlib/ -T -l t/
+	PLUGIN_TEST=1 PERL5LIB=tlib/:lib/ prove -Itlib/ -T -l t/
 test-v:
-	PERL5LIB=tlib/:lib/ prove -Itlib/ -T -l -w -o -v t/
+	PLUGIN_TEST=1 PERL5LIB=tlib/:lib/ prove -Itlib/ -T -l -w -o -v t/
 .PHONY:		all install clean

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -197,7 +197,7 @@ sub DEBUG {
     return if $ENV{PLUGIN_TEST}; # during the tests sp_confget is unavailable
     my $msg	  = shift // 'Empty message';
     my $data	  = [ @_ ];
-    state $config = sp_confget() || {};
+    state $config = { sp_confget() };
     state $timing = time(); # Time of last call
     my $time	  = time(); # Time now, must be hi-res
     my $duration  = sprintf("%.4f", $time - $timing);
@@ -206,7 +206,7 @@ sub DEBUG {
 
     # Reload config if last debug was more than 10 sec ago
     if( $duration > 10 ) {
-	$config = sp_confget() || {};
+	$config = { sp_confget() };
     }
 
     return if !$config || ref($config) ne 'HASH';

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -316,7 +316,7 @@ sub sp_post {
     my $addr   = shift // debug_die("Missing POST address");
     my $params = shift;
 
-    DEBUG("POST $addr: '".Dumper($params)."'");
+    DEBUG("POST $addr: '%s'", $params);
 
     return sp_request_retry( sub {
 	sp_request($cfg, 'POST', $addr, $params);

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -1709,7 +1709,7 @@ sub volume_size_info {
 	log_and_die "Internal error: unexpected size '$size' for $volname";
     }
 
-    DEBUG('volume_size_info result: size %, type raw', $size);
+    DEBUG('volume_size_info result: size %s, type raw', $size);
 
     # TODO: pp: do we ever need to support anything other than 'raw' here?
     return wantarray ? ($size, 'raw', $size, undef) : $size;

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -221,7 +221,7 @@ sub DEBUG {
 
     ($path) = ( $path =~ m{^((?:/[\w\-]+)*[\w\-]+\.\w+)$} );
 
-    confess("Invalid path _SP_PVE_DEBUG_PATH. Try with /var/log/storpool/debug.log")
+    confess("Invalid path '$config->{_SP_PVE_DEBUG_PATH}'. Try with /var/log/storpool/debug.log")
 	if !$path;
 
     if( scalar(@$data) ) {
@@ -368,7 +368,7 @@ sub sp_request {
 
     sp_request_log_response($method, $addr, $response, $duration);
 
-    DEBUG("RESULT: $method $addr $response $duration");
+    DEBUG("RESULT: %s %s %s %s", $method, $addr, $response, $duration);
 
     if ($response->code eq "200"){
 	undef $@;

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -229,7 +229,7 @@ sub DEBUG {
 	$msg = longmess($msg);
     }
 
-    $msg = _localtime_human() . " took $duration: " . $msg . "\n";
+    $msg = _localtime_human() . " [$$] took $duration: " . $msg . "\n";
 
     open( my $fh, '>>', $path ) 
 	or confess("Failed to open debug file '$path' for writing: '$!'");


### PR DESCRIPTION
DEBUG sub is added and placed at the enter and leave phases in the plugin main subs. Controlled via the storpool configuration _SP_PVE_DEBUG=[012] and _SP_PVE_DEBUG_PATH=IO::Path
It also measures the time duration since last debug call.