### PR TITLE
Volumes on multiclusters

### DIFF
--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -472,7 +472,16 @@ sub assert_sp_vol_local_cluster {
 
     my $cluster = sp_vol_get_tag($vol, VTAG_LOC);
 
-    if( $cluster && !sp_vol_tag_is($vol, VTAG_LOC, sp_get_loc_name($cfg)) ){
+    if( !$cluster && $vol->{globalId} ) {
+	if( !$vol->{snapshot} ){
+	   $vol = sp_vol_info_single($cfg, $vol->{globalId});
+	} else {
+	   $vol = sp_snap_info_single($cfg, $vol->{globalId});
+	}
+	$cluster = sp_vol_get_tag($vol, VTAG_LOC);
+    }
+
+    if( $cluster && $cluster ne sp_get_loc_name($cfg) ){
 	my $name = $vol->{name} // '';
 	my $type = $vol->{snapshot} ? 'Snapshot' : 'Volume';
 	die "$type '$name' is part of another cluster: " . $cluster;

--- a/lib/PVE/Storage/Custom/StorPoolPlugin.pm
+++ b/lib/PVE/Storage/Custom/StorPoolPlugin.pm
@@ -470,8 +470,9 @@ sub assert_sp_vol_local_cluster {
     my $vol = shift;
     my $cfg = shift;
 
-    if( !sp_vol_tag_is($vol, VTAG_LOC, sp_get_loc_name($cfg)) ){
-	my $cluster = sp_vol_get_tag($vol, VTAG_LOC) // '';
+    my $cluster = sp_vol_get_tag($vol, VTAG_LOC);
+
+    if( $cluster && !sp_vol_tag_is($vol, VTAG_LOC, sp_get_loc_name($cfg)) ){
 	my $name = $vol->{name} // '';
 	my $type = $vol->{snapshot} ? 'Snapshot' : 'Volume';
 	die "$type '$name' is part of another cluster: " . $cluster;

--- a/t/15_free_image.t
+++ b/t/15_free_image.t
@@ -75,6 +75,12 @@ mock_lwp_request(
                 }) 
             }
         }
+        elsif( $uri =~ m{/(Snapshot|Volume)/~\d+\.\d+\.\d+} ){
+
+            my $expected = {"tags"=>{"pve-loc"=>"storpool","pve-type"=>"iso","pve"=>"storeid","pve-comment"=>"test","pve-snap"=>"4.3.2","pve-snap"=>JSON::true,"virt"=>"pve"}};
+
+            return { code=>200, content => encode_json({generation=>12, data=>[$expected]}) };
+        }
 
     }
 );
@@ -106,7 +112,7 @@ $STAGE = 2;
 @endpoints = ();
 $result = $class->free_image('storeid',{}, $volname);
 is($result, undef, "$STAGE: snapshot delete");
-is_deeply(\@endpoints,['VolumesReassignWait','SnapshotDelete/~4.3.2'], "$STAGE: snapshot delete API call");
+is_deeply(\@endpoints,['Snapshot/~4.3.2','VolumesReassignWait','SnapshotDelete/~4.3.2'], "$STAGE: snapshot delete API call");
 
 undef $@;
 $STAGE = 3;
@@ -116,6 +122,6 @@ $expected_reassign_request = [{volume=>"~4.1.3", force=>JSON::false,detach=>'all
 $result = $class->free_image('storeid',{}, $volname);
 
 is($result, undef, "$STAGE: cleanup parent snapshots result OK");
-is_deeply(\@endpoints,['VolumesReassignWait','VolumeDelete/~4.1.3','SnapshotsList','SnapshotDelete/~12'], "$STAGE: API calls OK");
+is_deeply(\@endpoints,['Volume/~4.1.3','VolumesReassignWait','VolumeDelete/~4.1.3','SnapshotsList','SnapshotDelete/~12'], "$STAGE: API calls OK");
 
 done_testing();

--- a/t/21_volume_resize.t
+++ b/t/21_volume_resize.t
@@ -75,6 +75,12 @@ mock_lwp_request(
             is($content,'', "$STAGE: ClientConfigWait empty data request");
             return { code => 200, content => encode_json({generation=>12, data=>{ok=>JSON::true, clientGeneration=>666, configStatus=>'running',delay=>123,generation=>11,id=>11}}) }
         }
+        elsif( $uri =~ m{/(Snapshot|Volume)/~\d+\.\d+\.\d+} ){
+
+            my $expected = {"tags"=>{"pve-loc"=>"storpool","pve-type"=>"iso","pve"=>"storeid","pve-comment"=>"test","pve-snap"=>"4.3.2","pve-snap"=>JSON::true,"virt"=>"pve"}};
+
+            return { code=>200, content => encode_json({generation=>12, data=>[$expected]}) };
+        }
     }
 );
 
@@ -96,7 +102,7 @@ undef $@;
 my $result = $class->volume_resize({},'storeid', $volname, $size, $running) ;
 
 is(!!$result, 1, "$STAGE: volume resize OK");
-is_deeply(\@endpoints, ["VolumeUpdate/~$version",666], "$STAGE: volume resize API calls");
+is_deeply(\@endpoints, ['Snapshot/~4.3.2',"VolumeUpdate/~$version",666], "$STAGE: volume resize API calls");
 
 
 done_testing();

--- a/t/23_volume_snapshot.t
+++ b/t/23_volume_snapshot.t
@@ -52,6 +52,12 @@ mock_lwp_request(
 			is_deeply(decode_json($content), $expected, "API call POST data");
             return $response;
         }
+        elsif( $uri =~ m{/(Snapshot|Volume)/~\d+\.\d+\.\d+} ){
+
+            my $expected = {"tags"=>{"pve-loc"=>"storpool","pve-type"=>"iso","pve"=>"storeid","pve-comment"=>"test","pve-snap"=>"4.3.2","pve-snap"=>JSON::true,"virt"=>"pve"}};
+
+            return { code=>200, content => encode_json({generation=>12, data=>[$expected]}) };
+        }
 
     }
 );
@@ -70,7 +76,7 @@ undef $@;
 my $result = $class->volume_snapshot({},'storeid',$volname);
 
 is($result, undef, "Snapshot result");
-is_deeply(\@endpoints,["VolumeSnapshot/~$version"], "Correct API call used");
+is_deeply(\@endpoints,['Snapshot/~4.3.2',"VolumeSnapshot/~$version"], "Correct API call used");
 
 
 ## Error from the API
@@ -81,7 +87,7 @@ $result = eval { $class->volume_snapshot({},'storeid',$volname) };
 
 is($result,undef,"error result");
 like($@, qr/Main error/, "API error displayed");
-is_deeply(\@endpoints,["VolumeSnapshot/~$version"], "Correct API call used");
+is_deeply(\@endpoints,['Snapshot/~4.3.2',"VolumeSnapshot/~$version"], "Correct API call used");
 
 
 done_testing();

--- a/t/26_rename_volume.t
+++ b/t/26_rename_volume.t
@@ -68,6 +68,12 @@ mock_lwp_request(
 
             return { code => 200, content => encode_json( $response_vol_info ) }
         }
+        elsif( $uri =~ m{/(Snapshot|Volume)/~\d+\.\d+\.\d+} ){
+
+            my $expected = {"tags"=>{"pve-loc"=>"storpool","pve-type"=>"iso","pve"=>"storeid","pve-comment"=>"test","pve-snap"=>"4.3.2","pve-snap"=>JSON::true,"virt"=>"pve"}};
+
+            return { code=>200, content => encode_json({generation=>12, data=>[$expected]}) };
+        }
     }
 );
 
@@ -85,7 +91,7 @@ undef $@;
 my $result = $class->rename_volume({},'storeid',$volname);
 
 is($result, 'storeid:vm-5-cloudinit.raw', "Snapshot rollback result");
-is_deeply(\@endpoints,["VolumeUpdate/~$version","Volume/~$version"], "Correct API calls used");
+is_deeply(\@endpoints,['Snapshot/~4.1.3',"VolumeUpdate/~$version","Volume/~$version"], "Correct API calls used");
 
 
 done_testing();


### PR DESCRIPTION
Check on volume/snapshot operation if the target is meant for the current cluster, thus avoiding issues after migrating volumes/snapshots to other clusters and leaving the old one's risking data corruption, volume deletion etc.